### PR TITLE
Added cookie support

### DIFF
--- a/src/classes/audiomanager.js
+++ b/src/classes/audiomanager.js
@@ -271,6 +271,12 @@ class AudioManager extends EventEmitter{
     const player = globals[channel.id].get(`connection`);
     player.volume(`${volume}/10`);
   };
+  set cookie(newCookie){
+    ytstream.cookie = newCookie;
+  };
+  get cookie(){
+    return ytstream.cookie;
+  };
 };
 
 module.exports = {AudioManager};

--- a/src/classes/player.js
+++ b/src/classes/player.js
@@ -316,6 +316,12 @@ class Player extends EventEmitter {
             globals[this.channel.id].get(`resource`).volume.setVolumeLogarithmic(Number(vol[0]) / Number(vol[1]));
         }
     }
+    set cookie(newCookie){
+        ytstream.cookie = newCookie;
+    }
+    get cookie(){
+        return ytstream.cookie;
+    }
 };
 
 module.exports = {Player};


### PR DESCRIPTION
Hello!
I need to set the cookie to be able to play age restricted videos. I read this [issue](https://github.com/Luuk-Dev/DiscordAudio/issues/3) and the solution works fine, but it is not as easy as the rest to use.
What do you think of this implementation?

If the documentation is publicly editable I'll also add details about the cookie.
There this [PR on YT-Stream](https://github.com/Luuk-Dev/YT-Stream/pull/5) that would also make setting the cookie very easy.